### PR TITLE
patch to use the libtorrent system library when possible

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id='script.module.libtorrent' version='1.1.7' name='python-libtorrent' provider-name='DiMartino, srg70, RussakHH, aisman, inpos'>
+<addon id='script.module.libtorrent' version='1.2.1' name='python-libtorrent' provider-name='DiMartino, srg70, RussakHH, aisman, inpos'>
   <requires>
     <import addon='xbmc.python' version='2.1.0'/>
   </requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
-﻿1.1.7:
+﻿1.2.1:
+Try to use system library first when possible
+
+1.2.0:
+Added darwin binaries
+
+1.1.7:
 Added 1.1.6 and 1.1.7 for ARM v6 by Allin
 
 1.1.1:

--- a/python_libtorrent/python_libtorrent/__init__.py
+++ b/python_libtorrent/python_libtorrent/__init__.py
@@ -74,7 +74,11 @@ if not os.path.exists(sizefile_path):
             log('die because the folder is empty')
             exit()
 dest_path = os.path.join(dirname, platform['system'], platform['version'])
-sys.path.insert(0, dest_path)
+
+if (getSettingAsBool('custom_dirname') and set_dirname) or not platform["try-system-first"]:
+    sys.path.insert(0, dest_path)
+else:
+    sys.path.append(dest_path)
 
 lm=LibraryManager(dest_path, platform)
 if not lm.check_exist():
@@ -144,7 +148,7 @@ try:
         finally:
             if fp: fp.close()
 
-    log('Imported libtorrent v' + libtorrent.version + ' from "' + dest_path + '"')
+    log('Imported libtorrent v' + libtorrent.version + ' from "' + libtorrent.__file__ + '"')
 
 except Exception, e:
     log('Error importing libtorrent from "' + dest_path + '". Exception: ' + str(e))

--- a/python_libtorrent/python_libtorrent/platform_pulsar.py
+++ b/python_libtorrent/python_libtorrent/platform_pulsar.py
@@ -155,27 +155,33 @@ def get_platform():
 def get_system(ret):
     ret["system"] = ''
     ret["message"] = ['', '']
+    ret["try-system-first"] = False
 
     if ret["os"] == 'windows':
         ret["system"] = 'windows'
         ret["message"] = ['Windows has static compiled python-libtorrent included.',
                           'You should install "script.module.libtorrent" from "MyShows.me Kodi Repo"']
+        ret["try-system-first"] = True
     elif ret["os"] == "linux" and ret["arch"] == "x64":
         ret["system"] = 'linux_x86_64'
         ret["message"] = ['Linux x64 has not static compiled python-libtorrent included.',
                           'You should install it by "sudo apt-get install python-libtorrent"']
+        ret["try-system-first"] = True
     elif ret["os"] == "linux" and ret["arch"] == "x86":
         ret["system"] = 'linux_x86'
         ret["message"] = ['Linux has static compiled python-libtorrent included but it didn\'t work.',
                           'You should install it by "sudo apt-get install python-libtorrent"']
+        ret["try-system-first"] = True
     elif ret["os"] == "linux" and "aarch64" in ret["arch"]:
         ret["system"] = 'linux_' + ret["arch"]
         ret["message"] = ['Linux has static compiled python-libtorrent included but it didn\'t work.',
                           'You should install it by "sudo apt-get install python-libtorrent"']
+        ret["try-system-first"] = True
     elif ret["os"] == "linux" and ("arm" or "mips" in ret["arch"]):
         ret["system"] = 'linux_'+ret["arch"]
         ret["message"] = ['As far as I know you can compile python-libtorrent for ARMv6-7.',
                           'You should search for "OneEvil\'s OpenELEC libtorrent" or use Ace Stream.']
+        ret["try-system-first"] = False
     elif ret["os"] == "android":
         if ret["arch"]=='arm':
             ret["system"] = 'android_armv7'
@@ -183,13 +189,16 @@ def get_system(ret):
             ret["system"] = 'android_x86'
         ret["message"] = ['Please contact DiMartino on kodi.tv forum. We compiled python-libtorrent for Android,',
                           'but we need your help with some tests on different processors.']
+        ret["try-system-first"] = False
     elif ret["os"] == "darwin":
         ret["system"] = 'darwin'
         ret["message"] = ['It is possible to compile python-libtorrent for OS X.',
                           'But you would have to do it by yourself, there is some info on github.com.']
+        ret["try-system-first"] = False
     elif ret["os"] == "ios" and ret["arch"] == "arm":
         ret["system"] = 'ios_arm'
         ret["message"] = ['It is probably NOT possible to compile python-libtorrent for iOS.',
                           'But you can use torrent-client control functions.']
+        ret["try-system-first"] = False
 
     return ret


### PR DESCRIPTION
On platforms with dynamicaly linked libraries (eg: linux), try to use system library first, unless specifically requested otherwise by user